### PR TITLE
Add server-side mode option for OAuth endpoints

### DIFF
--- a/README.md
+++ b/README.md
@@ -135,6 +135,15 @@ austin.popup("twitter", function(data) {
 </script>
 ```
 
+## サーバサイド実装を行いたい場合
+
+Austinはクライアントサイドでの利用が前提ですが、`implementation=server` をクエリパラメータに追加することで、リファラーチェックをスキップしてサーバサイドのリクエストからもOAuthフローを開始・結果取得できます。
+
+- 認証開始: `https://your-domain/austin/oauth/{provider}/{app_key}?implementation=server&key={uuid}`
+- 結果取得: `https://your-domain/austin/result/{uuid}?implementation=server`
+
+アプリケーション側で適切な認可やCSRF対策を行った上で利用してください。
+
 ## プロジェクトに貢献する
 
 - このプロジェクトはオープンソースであり、誰でも改善提案やプルリクエストを歓迎します。

--- a/src/main/java/jp/livlog/austin/resource/OAuthResource.java
+++ b/src/main/java/jp/livlog/austin/resource/OAuthResource.java
@@ -28,15 +28,19 @@ public class OAuthResource extends AbsBaseResource {
             final var restletResponse = this.getResponse();
             // final var servletResponse = ServletUtils.getResponse(restletResponse);
             restletResponse.setAccessControlAllowOrigin("*");
-            final var referer = servletRequest.getHeader("REFERER");
-            var domainFlg = true;
-            for (final String domain : setting.getDomains()) {
-                if (referer.contains(domain)) {
-                    domainFlg = false;
+            final var serverSideRequest = this.isServerSideRequest(restletRequest.getOriginalRef().getQueryAsForm());
+            if (!serverSideRequest) {
+                final var referer = servletRequest.getHeader("REFERER");
+                final var refererValue = referer == null ? "" : referer;
+                var domainFlg = true;
+                for (final String domain : setting.getDomains()) {
+                    if (refererValue.contains(domain)) {
+                        domainFlg = false;
+                    }
                 }
-            }
-            if (domainFlg) {
-                throw new NotspecifiedDomainError("Not the specified domain.");
+                if (domainFlg) {
+                    throw new NotspecifiedDomainError("Not the specified domain.");
+                }
             }
 
             final var attrMap = this.getRequestAttributes();

--- a/src/main/java/jp/livlog/austin/resource/ResultResource.java
+++ b/src/main/java/jp/livlog/austin/resource/ResultResource.java
@@ -31,15 +31,19 @@ public class ResultResource extends AbsBaseResource {
             final var restletResponse = this.getResponse();
             // final var servletResponse = ServletUtils.getResponse(restletResponse);
             restletResponse.setAccessControlAllowOrigin("*");
-            final var referer = servletRequest.getHeader("REFERER");
-            var domainFlg = true;
-            for (final String domain : setting.getDomains()) {
-                if (referer.contains(domain)) {
-                    domainFlg = false;
+            final var serverSideRequest = this.isServerSideRequest(restletRequest.getOriginalRef().getQueryAsForm());
+            if (!serverSideRequest) {
+                final var referer = servletRequest.getHeader("REFERER");
+                final var refererValue = referer == null ? "" : referer;
+                var domainFlg = true;
+                for (final String domain : setting.getDomains()) {
+                    if (refererValue.contains(domain)) {
+                        domainFlg = false;
+                    }
                 }
-            }
-            if (domainFlg) {
-                throw new NotspecifiedDomainError("Not the specified domain.");
+                if (domainFlg) {
+                    throw new NotspecifiedDomainError("Not the specified domain.");
+                }
             }
 
             final var attrMap = this.getRequestAttributes();

--- a/src/main/java/jp/livlog/austin/share/AbsBaseResource.java
+++ b/src/main/java/jp/livlog/austin/share/AbsBaseResource.java
@@ -5,7 +5,9 @@ import java.io.InputStreamReader;
 import java.io.Reader;
 
 import org.apache.commons.io.IOUtils;
+import org.restlet.data.Parameter;
 import org.restlet.resource.ServerResource;
+import org.restlet.util.Series;
 
 import com.google.gson.Gson;
 
@@ -52,6 +54,23 @@ public abstract class AbsBaseResource extends ServerResource {
 
     /** GoogleService. */
     protected final GoogleService   googleService              = GoogleService.getInstance();
+
+    /**
+     * サーバサイドからの呼び出しか判定する.
+     *
+     * @param queryParameters クエリパラメータ
+     * @return サーバサイドからの呼び出しの場合はtrue
+     */
+    protected boolean isServerSideRequest(final Series <Parameter> queryParameters) {
+
+        if (queryParameters == null) {
+            return false;
+        }
+
+        final var impl = queryParameters.getFirstValue("implementation", true, "");
+
+        return "server".equalsIgnoreCase(impl);
+    }
 
     protected Setting getSetting() throws IOException {
 


### PR DESCRIPTION
## Summary
- allow OAuth and result endpoints to accept server-side calls via an implementation=server query parameter
- harden referer validation against missing headers while keeping existing protections for client requests
- document how to start authentication and fetch results from server-side flows

## Testing
- mvn test *(fails: Maven Central returned 403 for maven-resources-plugin)*


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6958850c1034832199bbc69c6f319ef7)