### PR TITLE
Add dynamic return URL support for OAuth callback redirects

### DIFF
--- a/src/main/java/jp/livlog/austin/resource/CallbackResource.java
+++ b/src/main/java/jp/livlog/austin/resource/CallbackResource.java
@@ -75,9 +75,13 @@ public class CallbackResource extends AbsBaseResource {
                 this.cookieScope("austin-error-message", "authentication_failure", servletResponse);
             }
 
-            var callbackURL = servletRequest.getRequestURL().toString();
-            final var index = callbackURL.indexOf("callback");
-            callbackURL = callbackURL.substring(0, index) + "app/close.html";
+            var callbackURL = (String) servletRequest.getSession().getAttribute("return_url");
+            if (callbackURL == null || callbackURL.isEmpty()) {
+                callbackURL = servletRequest.getRequestURL().toString();
+                final var index = callbackURL.indexOf("callback");
+                callbackURL = callbackURL.substring(0, index) + "app/close.html";
+            }
+            servletRequest.getSession().removeAttribute("return_url");
 
             final var newRef = new Reference(callbackURL);
             this.redirectSeeOther(newRef);

--- a/src/main/java/jp/livlog/austin/resource/OAuthResource.java
+++ b/src/main/java/jp/livlog/austin/resource/OAuthResource.java
@@ -49,6 +49,10 @@ public class OAuthResource extends AbsBaseResource {
             final var attrMap = this.getRequestAttributes();
             final var provider = (String) attrMap.get("provider");
             final var appKey = (String) attrMap.get("app_key");
+            final var returnUrl = servletRequest.getParameter("return_url");
+            if (returnUrl != null && !returnUrl.isEmpty()) {
+                servletRequest.getSession().setAttribute("return_url", returnUrl);
+            }
 
             String uriReference = null;
             switch (Objects.requireNonNull(ProviderType.getType(provider))) {


### PR DESCRIPTION
### Motivation
- Allow callers to specify a dynamic redirect target so the app can return users to a custom URL after completing OAuth.
- Preserve existing behavior by falling back to the default `app/close.html` when no return URL is provided.

### Description
- Read the `return_url` query parameter in `OAuthResource` and store it in the session via `servletRequest.getSession().setAttribute("return_url", ...)` when present.
- In `CallbackResource`, read the session `return_url` and redirect to it after processing the OAuth callback, and remove the session attribute after use.
- Fall back to constructing the default close page URL (`app/close.html`) when `return_url` is not set.
- Modified files: `src/main/java/jp/livlog/austin/resource/OAuthResource.java` and `src/main/java/jp/livlog/austin/resource/CallbackResource.java`.

### Testing
- No automated tests were executed for this change.
- Local compile/run verification was not recorded by the rollout tools.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_695e381a8d5883218708b78ce2f5ede3)