### PR TITLE
Validate server-side `return_url` against allowed domains and use session redirect

### DIFF
--- a/README.md
+++ b/README.md
@@ -140,9 +140,11 @@ austin.popup("twitter", function(data) {
 Austinはクライアントサイドでの利用が前提ですが、`implementation=server` をクエリパラメータに追加することで、リファラーチェックをスキップしてサーバサイドのリクエストからもOAuthフローを開始・結果取得できます。
 
 - 認証開始: `https://your-domain/austin/oauth/{provider}/{app_key}?implementation=server&key={uuid}`
+- 認証開始 (戻り先指定): `https://your-domain/austin/oauth/{provider}/{app_key}?implementation=server&key={uuid}&return_url={urlencoded_return_url}`
 - 結果取得: `https://your-domain/austin/result/{uuid}?implementation=server`
 
 アプリケーション側で適切な認可やCSRF対策を行った上で利用してください。
+`return_url` は `setting.json` で許可されたドメインに含まれるURLのみ受け付けます。
 
 ## プロジェクトに貢献する
 

--- a/src/main/java/jp/livlog/austin/resource/CallbackResource.java
+++ b/src/main/java/jp/livlog/austin/resource/CallbackResource.java
@@ -75,9 +75,13 @@ public class CallbackResource extends AbsBaseResource {
                 this.cookieScope("austin-error-message", "authentication_failure", servletResponse);
             }
 
-            var callbackURL = servletRequest.getRequestURL().toString();
-            final var index = callbackURL.indexOf("callback");
-            callbackURL = callbackURL.substring(0, index) + "app/close.html";
+            var callbackURL = (String) servletRequest.getSession().getAttribute("return_url");
+            if (callbackURL == null || callbackURL.isEmpty()) {
+                callbackURL = servletRequest.getRequestURL().toString();
+                final var index = callbackURL.indexOf("callback");
+                callbackURL = callbackURL.substring(0, index) + "app/close.html";
+            }
+            servletRequest.getSession().removeAttribute("return_url");
 
             final var newRef = new Reference(callbackURL);
             this.redirectSeeOther(newRef);

--- a/src/main/java/jp/livlog/austin/resource/OAuthResource.java
+++ b/src/main/java/jp/livlog/austin/resource/OAuthResource.java
@@ -11,6 +11,7 @@ import jp.livlog.austin.share.AbsBaseResource;
 import jp.livlog.austin.share.ProviderType;
 import lombok.extern.slf4j.Slf4j;
 
+import java.net.URI;
 import java.util.Objects;
 
 /**
@@ -49,6 +50,21 @@ public class OAuthResource extends AbsBaseResource {
             final var attrMap = this.getRequestAttributes();
             final var provider = (String) attrMap.get("provider");
             final var appKey = (String) attrMap.get("app_key");
+            final var returnUrl = servletRequest.getParameter("return_url");
+            if (returnUrl != null && !returnUrl.isEmpty()) {
+                try {
+                    final var parsedReturnUrl = URI.create(returnUrl);
+                    final var host = parsedReturnUrl.getHost();
+                    final var scheme = parsedReturnUrl.getScheme();
+                    if (host != null
+                            && ("http".equalsIgnoreCase(scheme) || "https".equalsIgnoreCase(scheme))
+                            && setting.getDomains().stream().anyMatch(host::contains)) {
+                        servletRequest.getSession().setAttribute("return_url", returnUrl);
+                    }
+                } catch (final IllegalArgumentException e) {
+                    OAuthResource.log.warn("Invalid return_url provided: {}", returnUrl);
+                }
+            }
 
             String uriReference = null;
             switch (Objects.requireNonNull(ProviderType.getType(provider))) {


### PR DESCRIPTION
### Motivation
- Allow server-side OAuth flows to accept a caller-provided `return_url` to redirect back after the callback completes.
- Prevent open-redirect risk by restricting `return_url` to only configured, allowed domains from `setting.json`.
- Ensure the callback can reliably redirect to the provided URL in a safe way while preserving the previous default behavior.

### Description
- In `OAuthResource`, parse the `return_url` with `URI.create(...)` and only set it into the session when the scheme is `http`/`https` and the URL host matches a domain from `setting.getDomains()`.
- In `CallbackResource`, read `return_url` from the session, remove the session attribute after use, and fall back to `app/close.html` when no valid `return_url` is present.
- Updated `README.md` to document that `return_url` is only accepted when its domain is listed in `setting.json`.
- Invalid or unparsable `return_url` values are now logged with a warning instead of being accepted.

### Testing
- No automated tests were executed for these changes.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_695e381a8d5883218708b78ce2f5ede3)