### PR TITLE
Parse referer host for strict domain checks

### DIFF
--- a/src/main/java/jp/livlog/austin/resource/OAuthResource.java
+++ b/src/main/java/jp/livlog/austin/resource/OAuthResource.java
@@ -35,14 +35,7 @@ public class OAuthResource extends AbsBaseResource {
             if (!serverSideRequest) {
                 final var referer = servletRequest.getHeader("REFERER");
                 final var refererValue = referer == null ? "" : referer;
-                var domainFlg = true;
-                for (final String domain : setting.getDomains()) {
-                    if (refererValue.contains(domain)) {
-                        domainFlg = false;
-                        break;
-                    }
-                }
-                if (domainFlg) {
+                if (!this.isAllowedRefererDomain(refererValue, setting.getDomains())) {
                     throw new NotspecifiedDomainError("Not the specified domain.");
                 }
             }

--- a/src/main/java/jp/livlog/austin/resource/ResultResource.java
+++ b/src/main/java/jp/livlog/austin/resource/ResultResource.java
@@ -35,14 +35,7 @@ public class ResultResource extends AbsBaseResource {
             if (!serverSideRequest) {
                 final var referer = servletRequest.getHeader("REFERER");
                 final var refererValue = referer == null ? "" : referer;
-                var domainFlg = true;
-                for (final String domain : setting.getDomains()) {
-                    if (refererValue.contains(domain)) {
-                        domainFlg = false;
-                        break;
-                    }
-                }
-                if (domainFlg) {
+                if (!this.isAllowedRefererDomain(refererValue, setting.getDomains())) {
                     throw new NotspecifiedDomainError("Not the specified domain.");
                 }
             }

--- a/src/main/java/jp/livlog/austin/share/AbsBaseResource.java
+++ b/src/main/java/jp/livlog/austin/share/AbsBaseResource.java
@@ -3,6 +3,8 @@ package jp.livlog.austin.share;
 import java.io.IOException;
 import java.io.InputStreamReader;
 import java.io.Reader;
+import java.net.URI;
+import java.util.List;
 
 import org.apache.commons.io.IOUtils;
 import org.restlet.data.Parameter;
@@ -101,6 +103,28 @@ public abstract class AbsBaseResource extends ServerResource {
         return IOUtils.toString(reader);
     }
 
+    protected boolean isAllowedRefererDomain(final String refererValue, final List <String> domains) {
+
+        if (refererValue == null || refererValue.isEmpty() || domains == null || domains.isEmpty()) {
+            return false;
+        }
+
+        try {
+            final var uri = URI.create(refererValue);
+            final var host = uri.getHost();
+            if (host == null) {
+                return false;
+            }
+            for (final String domain : domains) {
+                if (host.equalsIgnoreCase(domain)) {
+                    return true;
+                }
+            }
+            return false;
+        } catch (final IllegalArgumentException e) {
+            return false;
+        }
+    }
 
     /**
      * @param name CharSequence


### PR DESCRIPTION
### Motivation

- Enforce strict referer validation by matching the parsed host exactly rather than using substring checks to reduce spoofing risk.
- Centralize referer parsing and validation logic so multiple resources can reuse the same behavior.

### Description

- Add `isAllowedRefererDomain` to `AbsBaseResource` which uses `URI.create` and `getHost()` to compare the host against a `List<String>` of allowed domains with `equalsIgnoreCase`.
- Replace the previous `contains`-based referer checks in `OAuthResource` and `ResultResource` with calls to `isAllowedRefererDomain` and throw `NotspecifiedDomainError` when validation fails.
- Add required imports for `URI` and `List`, and ensure invalid or unparsable referer values are treated as disallowed.

### Testing

- No automated tests were executed as part of this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_695ed40422e083218d0b2aa0ef5754b4)