### PR TITLE
Prefer Origin header for strict domain checks

### DIFF
--- a/src/main/java/jp/livlog/austin/resource/OAuthResource.java
+++ b/src/main/java/jp/livlog/austin/resource/OAuthResource.java
@@ -33,16 +33,10 @@ public class OAuthResource extends AbsBaseResource {
             restletResponse.setAccessControlAllowOrigin("*");
             final var serverSideRequest = this.isServerSideRequest(restletRequest.getOriginalRef().getQueryAsForm());
             if (!serverSideRequest) {
+                final var origin = servletRequest.getHeader("ORIGIN");
                 final var referer = servletRequest.getHeader("REFERER");
                 final var refererValue = referer == null ? "" : referer;
-                var domainFlg = true;
-                for (final String domain : setting.getDomains()) {
-                    if (refererValue.contains(domain)) {
-                        domainFlg = false;
-                        break;
-                    }
-                }
-                if (domainFlg) {
+                if (!this.isAllowedRequestDomain(origin, refererValue, setting.getDomains())) {
                     throw new NotspecifiedDomainError("Not the specified domain.");
                 }
             }

--- a/src/main/java/jp/livlog/austin/resource/ResultResource.java
+++ b/src/main/java/jp/livlog/austin/resource/ResultResource.java
@@ -33,16 +33,10 @@ public class ResultResource extends AbsBaseResource {
             restletResponse.setAccessControlAllowOrigin("*");
             final var serverSideRequest = this.isServerSideRequest(restletRequest.getOriginalRef().getQueryAsForm());
             if (!serverSideRequest) {
+                final var origin = servletRequest.getHeader("ORIGIN");
                 final var referer = servletRequest.getHeader("REFERER");
                 final var refererValue = referer == null ? "" : referer;
-                var domainFlg = true;
-                for (final String domain : setting.getDomains()) {
-                    if (refererValue.contains(domain)) {
-                        domainFlg = false;
-                        break;
-                    }
-                }
-                if (domainFlg) {
+                if (!this.isAllowedRequestDomain(origin, refererValue, setting.getDomains())) {
                     throw new NotspecifiedDomainError("Not the specified domain.");
                 }
             }

--- a/src/main/java/jp/livlog/austin/share/AbsBaseResource.java
+++ b/src/main/java/jp/livlog/austin/share/AbsBaseResource.java
@@ -3,6 +3,8 @@ package jp.livlog.austin.share;
 import java.io.IOException;
 import java.io.InputStreamReader;
 import java.io.Reader;
+import java.net.URI;
+import java.util.List;
 
 import org.apache.commons.io.IOUtils;
 import org.restlet.data.Parameter;
@@ -101,6 +103,44 @@ public abstract class AbsBaseResource extends ServerResource {
         return IOUtils.toString(reader);
     }
 
+    protected boolean isAllowedRequestDomain(final String originValue, final String refererValue, final List <String> domains) {
+
+        if (domains == null || domains.isEmpty()) {
+            return false;
+        }
+
+        if (originValue != null && !originValue.isEmpty()) {
+            if (this.isAllowedDomainByUri(originValue, domains)) {
+                return true;
+            }
+            return false;
+        }
+
+        if (refererValue == null || refererValue.isEmpty()) {
+            return false;
+        }
+
+        return this.isAllowedDomainByUri(refererValue, domains);
+    }
+
+    private boolean isAllowedDomainByUri(final String uriValue, final List <String> domains) {
+
+        try {
+            final var uri = URI.create(uriValue);
+            final var host = uri.getHost();
+            if (host == null) {
+                return false;
+            }
+            for (final String domain : domains) {
+                if (host.equalsIgnoreCase(domain)) {
+                    return true;
+                }
+            }
+            return false;
+        } catch (final IllegalArgumentException e) {
+            return false;
+        }
+    }
 
     /**
      * @param name CharSequence


### PR DESCRIPTION
### Motivation

- Prefer the `Origin` header for domain validation and fall back to `Referer` when `Origin` is not present to address concerns about relying solely on `Referer`.
- Replace substring-based domain checks with strict host comparisons to reduce spoofing risk.
- Centralize URI parsing and host comparison logic to make validation reusable and clearer across resources.

### Description

- Add `isAllowedRequestDomain(String originValue, String refererValue, List<String> domains)` to `AbsBaseResource` which prefers `Origin` and falls back to `Referer` and delegates to a helper for URI parsing.
- Add private helper `isAllowedDomainByUri(String uriValue, List<String> domains)` that uses `URI.create` and compares `getHost()` to configured domains using `equalsIgnoreCase` and treats unparsable values as disallowed.
- Update `OAuthResource` and `ResultResource` to read the `ORIGIN` header and call `isAllowedRequestDomain` instead of the previous `contains`-based checks.
- Add required imports for `URI` and `List` and ensure empty/missing headers or domains cause validation to fail.

### Testing

- No automated tests were executed for this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_695ed40422e083218d0b2aa0ef5754b4)