### PR TITLE
Add GitHub OAuth provider and align README with implementation

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,157 +2,125 @@
 
 [![Build Status](https://travis-ci.org/livlog-llc/austin.svg?branch=master)](https://travis-ci.org/livlog-llc/austin)  [![Open Source](https://badges.frapsoft.com/os/v1/open-source.svg?v=103)](https://github.com/livlog-llc/austin) [![Java Version](https://img.shields.io/badge/java-17-blue.svg)](https://openjdk.java.net/projects/jdk/17/)
 
-**Austin**は、Java17を基盤とし、Tomcat Webサーバーで動作するオープンソースのOAuth認証統合ソリューションです。
+**Austin**は、Java 17 + Tomcat 環境で動作する OAuth 認証統合ミドルウェアです。
 
-## 何ができるのか？
+## 何ができるのか
 
-このプロジェクトは、SNSプラットフォーム（Twitter、Facebook、LINEなど）のOAuth認証を簡単に統合し、Web開発者がAPI統合に費やす時間を削減することができます。
+フロントエンドから `austin.js` を呼び出すだけで、複数プロバイダーの OAuth 認証を共通のインターフェースで実行できます。
 
-## 主な特徴
+## 対応プロバイダー
 
-- **対応プラットフォーム**: 複数の主要なSNSに対応。
-- **OAuth認証の簡素化**: 複雑な認証プロセスを抽象化し、簡単に統合。
-- **オープンソース**: 誰でも利用・改善が可能。
+現在の実装で利用できる `provider_name` は以下です。
+
+- `twitter`
+- `facebook`
+- `line`
+- `trello`
+- `slack`
+- `discord`
+- `google`
+- `github`
 
 ## インストール
 
 ### 必要条件
-- Java 17がインストールされていること
-- Maven 3.6.3以上がインストールされていること
 
-### インストール手順
+- Java 17
+- Maven 3.6.3+
+- Tomcat 10+（Jakarta Servlet API 6.0 系）
 
-1. **プロジェクトのクローン**
+### 手順
+
+1. **プロジェクトをクローン**
+
    ```sh
-   git clone https://github.com/austin/austin.git
+   git clone https://github.com/livlog-llc/austin.git
    cd austin
    ```
 
-2. **Mavenを使用した依存関係の解決とビルド**
+2. **ビルド**
+
    ```sh
    mvn clean install
    ```
 
-   このコマンドは、`pom.xml` に定義された依存関係を解決し、プロジェクトをビルドします。このプロセスは、必要なライブラリをダウンロードし、アプリケーションの実行可能なWARファイルを生成します。
+3. **デプロイ**
 
-3. **WARファイルのデプロイ**
-   生成された `austin.war` ファイルをTomcatまたは任意のJava対応Webサーバーにデプロイします。
+   生成された `target/austin.war` を Tomcat に配置します。
 
-## `settings.json` 設定方法
+## 設定ファイル (`setting.json`)
 
-### ファイルの配置
-プロジェクトディレクトリの `src/main/resources` フォルダに `settings.json` ファイルを配置してください。このファイルは、アプリケーションが起動時に読み込む設定情報を含んでいます。
+### 配置場所
 
-### 設定ファイルの編集
-`settings.json` は以下のように構成されています。
+`src/main/resources/setting.json`
 
-- **domains**: 認証リクエストを許可するドメインのリスト。ローカル開発や実運用環境のドメインを指定します。
-- **providers**: 各OAuthプロバイダー（SNSサービス等）の設定。各プロバイダーごとに設定を行います。
+> リポジトリにはテンプレートとして `src/main/resources/setting_sample.json` があるため、コピーして `setting.json` を作成してください。
 
-以下のテンプレートを基に、実際の値に置き換えて設定してください。
+### 構造
 
-```json
-{
-  "domains": [
-    "your-local-ip:port",
-    "your-production-domain.com"
-  ],
-  "providers": [
-    {
-      "app_name": "実際のアプリケーション名",
-      "app_key": "アプリケーション固有のキー",
-      "provider_name": "プロバイダ名（例：twitter）",
-      "client_id": "プロバイダから取得したクライアントID",
-      "client_secret": "プロバイダから取得したクライアントシークレット",
-      "scope": "リクエストする権限（例：email,user_posts）",
-      "apiVersion": "使用するAPIのバージョン（例：v4.0）"
-    }
-    // 他のプロバイダーも同様に追加
-  ]
-}
-```
-
-### `app_key` の生成
-`app_key` はセキュリティを強化するために、ランダムな値を生成して使用することが推奨されます。パスワード生成ツールを利用して、一意かつ安全なキーを生成してください。
-
-以下のウェブサイトで生成することができます：[ランダムキー生成ツール](https://www.luft.co.jp/cgi/randam.php)
-
-### 設定例と参考資料
-`src/main/resources` ディレクトリには `setting_sample.json` というサンプル設定ファイルも配置されています。このファイルを参考にして、具体的な設定値を理解し、自身のプロジェクトに合わせてカスタマイズしてください。
-
-以下は具体的な設定の例です。
+- `domains`: 許可するリクエスト元ドメイン（**ホスト名のみ**を推奨）
+- `providers`: OAuth プロバイダーごとの設定
 
 ```json
 {
   "domains": [
-    "127.0.0.1:5500",
+    "127.0.0.1",
     "example.com"
   ],
   "providers": [
     {
       "app_name": "MyApp",
       "app_key": "myapp123",
-      "provider_name": "twitter",
-      "client_id": "123abc",
-      "client_secret": "456def",
-      "scope": "email,user_posts",
-      "apiVersion": "v4.0"
-    },
-    {
-      "app_name": "MyApp",
-      "app_key": "myapp123",
-      "provider_name": "google",
-      "client_id": "789ghi",
-      "client_secret": "101jkl",
-      "scope": "openid",
+      "provider_name": "github",
+      "client_id": "xxxx",
+      "client_secret": "yyyy",
+      "scope": "read:user user:email",
       "apiVersion": ""
     }
   ]
 }
 ```
 
-### ファイルの検証
-ファイルを配置した後、アプリケーションを再起動して、設定が正しく読み込まれていることを確認してください。問題がある場合は、設定ファイルの構文と値を再確認してください。
+### 主な注意点
 
-## 使い方
+- `provider_name` は上記「対応プロバイダー」の文字列と完全一致させてください。
+- `twitter` は `apiVersion` が `2.0` の場合に OAuth 2.0 フローで動作します。
+- `facebook` は Graph API バージョン解決に `apiVersion` を使用します（例: `v20.0`）。
 
-JavaScriptから簡単にSNS認証をトリガーすることができます。以下のスクリプトをWebページに追加してください。
+## 使い方（クライアントサイド）
 
 ```html
-<script src="your-domain/austin/app/austin.js"></script>
+<script src="https://your-domain/austin/app/austin.js"></script>
 <script>
-const austin = new Austin("your-domain", "your-app-key");
-austin.popup("twitter", function(data) {
-    if (data.status == 'ok') {
-        console.log(data.provider);
-        console.log(data.id);
-        console.log(data.oauthToken);
-        console.log(data.oauthTokenSecret);
-    } else if (data.status == 'ng') {
-        console.log(data.errorMessage);
-    }
+const austin = new Austin("https://your-domain", "your-app-key");
+
+austin.popup("github", function(data) {
+  if (data.status === 'ok') {
+    console.log(data.provider);         // github
+    console.log(data.id);               // provider user id
+    console.log(data.oauthToken);       // access token
+    console.log(data.oauthTokenSecret); // OAuth1系のみ（未使用なら空）
+    console.log(data.other);            // provider依存の追加情報（必要時）
+  } else {
+    console.log(data.errorMessage);
+  }
 });
 </script>
 ```
 
-## サーバサイド実装を行いたい場合
+## サーバサイドフロー
 
-Austinはクライアントサイドでの利用が前提ですが、`implementation=server` をクエリパラメータに追加することで、リファラーチェックをスキップしてサーバサイドのリクエストからもOAuthフローを開始・結果取得できます。
+`implementation=server` を付与すると、サーバサイド利用モードで呼び出せます。
 
-- 認証開始: `https://your-domain/austin/oauth/{provider}/{app_key}?implementation=server&key={uuid}`
-- 認証開始 (戻り先指定): `https://your-domain/austin/oauth/{provider}/{app_key}?implementation=server&key={uuid}&return_url={urlencoded_return_url}`
-- 結果取得: `https://your-domain/austin/result/{uuid}?implementation=server`
+- 認証開始:
+  - `https://your-domain/austin/oauth/{provider}/{app_key}?implementation=server&key={uuid}`
+- 認証開始（戻り先指定）:
+  - `https://your-domain/austin/oauth/{provider}/{app_key}?implementation=server&key={uuid}&return_url={urlencoded_return_url}`
+- 結果取得:
+  - `https://your-domain/austin/result/{uuid}?implementation=server`
 
-アプリケーション側で適切な認可やCSRF対策を行った上で利用してください。
-`return_url` は `setting.json` で許可されたドメインに含まれるURLのみ受け付けます。
-
-## プロジェクトに貢献する
-
-- このプロジェクトはオープンソースであり、誰でも改善提案やプルリクエストを歓迎します。
-- [バグ報告](https://github.com/livlog-llc/austin/issues)
-- [機能リクエスト](https://github.com/livlog-llc/austin/issues)
-- [プルリクエスト](https://github.com/livlog-llc/austin/pulls)
+`return_url` のホストは `setting.json` の `domains` に含まれている必要があります。
 
 ## ライセンス
 
-このプロジェクトはMIT Licenseのもとで公開されています。
+MIT License

--- a/src/main/java/jp/livlog/austin/resource/CallbackResource.java
+++ b/src/main/java/jp/livlog/austin/resource/CallbackResource.java
@@ -61,6 +61,9 @@ public class CallbackResource extends AbsBaseResource {
                     case GOOGLE:
                         result = this.googleService.callback(setting, appKey, servletRequest);
                         break;
+                    case GITHUB:
+                        result = this.githubService.callback(setting, appKey, servletRequest);
+                        break;
                     default:
                         break;
                 }

--- a/src/main/java/jp/livlog/austin/resource/OAuthResource.java
+++ b/src/main/java/jp/livlog/austin/resource/OAuthResource.java
@@ -76,6 +76,9 @@ public class OAuthResource extends AbsBaseResource {
                 case GOOGLE:
                     uriReference = this.googleService.auth(setting, appKey, servletRequest);
                     break;
+                case GITHUB:
+                    uriReference = this.githubService.auth(setting, appKey, servletRequest);
+                    break;
                 default:
                     break;
             }

--- a/src/main/java/jp/livlog/austin/service/GithubService.java
+++ b/src/main/java/jp/livlog/austin/service/GithubService.java
@@ -1,0 +1,124 @@
+package jp.livlog.austin.service;
+
+import com.github.scribejava.apis.GitHubApi;
+import com.github.scribejava.core.builder.ServiceBuilder;
+import com.github.scribejava.core.model.OAuthRequest;
+import com.github.scribejava.core.model.Verb;
+import com.github.scribejava.core.oauth.OAuth20Service;
+
+import org.json.JSONObject;
+
+import jakarta.servlet.http.HttpServletRequest;
+import jp.livlog.austin.data.Provider;
+import jp.livlog.austin.data.Result;
+import jp.livlog.austin.data.Setting;
+import jp.livlog.austin.share.InfBaseService;
+import jp.livlog.austin.share.ProviderType;
+import lombok.extern.slf4j.Slf4j;
+
+/**
+ * GitHubサービス.
+ *
+ * @author H.Aoshima
+ * @version 1.0
+ *
+ */
+@Slf4j
+public class GithubService implements InfBaseService {
+
+    /** インスタンス. */
+    private static GithubService instance = new GithubService();
+
+    /**
+     * インスタンス取得メソッド.
+     * @return インスタンス
+     */
+    public static GithubService getInstance() {
+
+        return GithubService.instance;
+    }
+
+
+    @Override
+    public String auth(final Setting setting, final String appKey, final HttpServletRequest request) throws Exception {
+
+        Provider githubProvider = null;
+        for (final Provider provider : setting.getProviders()) {
+            if (ProviderType.GITHUB.name.equals(provider.getProviderName()) && provider.getAppKey().equals(appKey)) {
+                githubProvider = provider;
+                break;
+            }
+        }
+
+        if (githubProvider == null) {
+            throw new Exception("Could not get the provider.");
+        }
+
+        final var service = new ServiceBuilder(githubProvider.getClientId())
+                .apiSecret(githubProvider.getClientSecret())
+                .callback(this.getCallback(appKey, request))
+                .defaultScope(githubProvider.getScope())
+                .build(GitHubApi.instance());
+
+        final var authorizationUrl = service.getAuthorizationUrl();
+
+        GithubService.log.info(authorizationUrl);
+        request.getSession().setAttribute("service", service);
+
+        return authorizationUrl;
+    }
+
+
+    @Override
+    public String getCallback(final String appKey, final HttpServletRequest request) {
+
+        final var callbackURL = request.getRequestURL().toString();
+
+        return callbackURL.replace("oauth", "callback");
+    }
+
+
+    @Override
+    public Result callback(final Setting setting, final String appKey, final HttpServletRequest request) throws Exception {
+
+        Provider githubProvider = null;
+        for (final Provider provider : setting.getProviders()) {
+            if (ProviderType.GITHUB.name.equals(provider.getProviderName()) && provider.getAppKey().equals(appKey)) {
+                githubProvider = provider;
+                break;
+            }
+        }
+
+        if (githubProvider == null) {
+            throw new Exception("Could not get the provider.");
+        }
+
+        final var result = new Result();
+
+        final var service = (OAuth20Service) request.getSession().getAttribute("service");
+
+        final var code = request.getParameter("code");
+
+        final var accessToken = service.getAccessToken(code);
+        request.getSession().removeAttribute("service");
+
+        final var oauthToken = accessToken.getAccessToken();
+
+        final var oauthRequest = new OAuthRequest(Verb.GET, "https://api.github.com/user");
+        service.signRequest(accessToken, oauthRequest);
+        try (var response = service.execute(oauthRequest)) {
+            if (!response.isSuccessful()) {
+                throw new Exception("Failed to fetch user info");
+            }
+
+            final var jsonResponse = new JSONObject(response.getBody());
+            final var userId = jsonResponse.get("id").toString();
+
+            result.setId(userId);
+            result.setOauthToken(oauthToken);
+        }
+
+        return result;
+    }
+
+}

--- a/src/main/java/jp/livlog/austin/share/AbsBaseResource.java
+++ b/src/main/java/jp/livlog/austin/share/AbsBaseResource.java
@@ -20,6 +20,7 @@ import jp.livlog.austin.data.Setting;
 import jp.livlog.austin.service.DiscordService;
 import jp.livlog.austin.service.FacebookService;
 import jp.livlog.austin.service.GoogleService;
+import jp.livlog.austin.service.GithubService;
 import jp.livlog.austin.service.LineService;
 import jp.livlog.austin.service.SlackService;
 import jp.livlog.austin.service.TrelloService;
@@ -56,6 +57,9 @@ public abstract class AbsBaseResource extends ServerResource {
 
     /** GoogleService. */
     protected final GoogleService   googleService              = GoogleService.getInstance();
+
+    /** GithubService. */
+    protected final GithubService   githubService              = GithubService.getInstance();
 
     /**
      * サーバサイドからの呼び出しか判定する.

--- a/src/main/java/jp/livlog/austin/share/ProviderType.java
+++ b/src/main/java/jp/livlog/austin/share/ProviderType.java
@@ -22,6 +22,8 @@ public enum ProviderType {
     DISCORD(6, "discord"),
     /** Google. */
     GOOGLE(7, "google"),
+    /** GitHub. */
+    GITHUB(8, "github"),
     ;
 
     /** cd. */

--- a/src/main/resources/setting_sample.json
+++ b/src/main/resources/setting_sample.json
@@ -67,6 +67,15 @@
       "client_secret": "<-client_secret->",
       "scope": "openid",
       "apiVersion": ""
+    },
+    {
+      "app_name": "<-app_name->",
+      "app_key": "<-app_key->",
+      "provider_name": "github",
+      "client_id": "-client_id->",
+      "client_secret": "<-client_secret->",
+      "scope": "read:user user:email",
+      "apiVersion": ""
     }
   ]
 }


### PR DESCRIPTION
### Motivation

- Add first-class GitHub OAuth support so the application can start/complete GitHub OAuth flows like the other providers.
- Ensure server configuration and usage docs reflect the actual runtime behavior and supported providers to reduce onboarding friction.

### Description

- Implemented `GithubService` (`src/main/java/jp/livlog/austin/service/GithubService.java`) that uses ScribeJava `GitHubApi` to build the authorization URL, exchange the code for an access token, and fetch the user `id` from `https://api.github.com/user`.
- Added `GITHUB` to the `ProviderType` enum (`src/main/java/jp/livlog/austin/share/ProviderType.java`) and injected `GithubService` into `AbsBaseResource` (`src/main/java/jp/livlog/austin/share/AbsBaseResource.java`).
- Wired GitHub handling into the web flow by adding `GITHUB` cases to `OAuthResource` and `CallbackResource` so `/oauth/github/{app_key}` and `/callback/github/{app_key}` are processed like other providers.
- Updated documentation and samples: revised `README.md` to match the implementation (use `setting.json` from `setting_sample.json`, list of supported `provider_name` values, client/server usage examples) and added a GitHub entry to `src/main/resources/setting_sample.json`.

### Testing

- Attempted a build with `mvn -q -DskipTests compile`, which failed due to plugin resolution errors from Maven Central (HTTP 403) in this environment, so no full compile or integration run completed.
- No automated unit tests were present or executed as part of this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69908cebc08c83218e1b4310fbd28505)